### PR TITLE
Add Rails 5.1 compatibility

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -7,5 +7,5 @@ appraise "railties-4.x" do
 end
 
 appraise "railties-5.x" do
-  gem "railties", "~> 5.0"
+  gem "railties", "~> 5.1"
 end

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ response headers.
 The SHAHeader gem is compatible with:
 
 * Ruby 2.1 through 2.4, and
-* Rails 3.2 through 5.0.
+* Rails 3.2 through 5.1.
 
 ## Installation
 
@@ -40,7 +40,7 @@ application has added the above `Gemfile` line.  Using curl:
 
 And, the following response is received:
 
-    HTTP/1.1 200 OK 
+    HTTP/1.1 200 OK
     Content-Type: text/html; charset=utf-8
     ETag: "25ec427afba8daa376f309559b1b3c5c"
     Cache-Control: max-age=0, private, must-revalidate

--- a/gemfiles/railties_3.2.gemfile
+++ b/gemfiles/railties_3.2.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "railties", "~> 3.2"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/railties_4.x.gemfile
+++ b/gemfiles/railties_4.x.gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 gem "railties", "~> 4.0"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/gemfiles/railties_5.x.gemfile
+++ b/gemfiles/railties_5.x.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "railties", "~> 5.0"
+gem "railties", "~> 5.1"
 
-gemspec :path => "../"
+gemspec path: "../"

--- a/lib/sha_header/railtie.rb
+++ b/lib/sha_header/railtie.rb
@@ -4,7 +4,7 @@ require 'rails'
 module SHAHeader
   class Railtie < Rails::Railtie
     initializer "sha_header.use_rack_middleware" do |app|
-      app.middleware.use "SHAHeader::Middleware"
+      app.middleware.use SHAHeader::Middleware
     end
   end
 end

--- a/sha_header.gemspec
+++ b/sha_header.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'railties', '>= 3.2', '< 5.1'
+  spec.add_dependency 'railties', '>= 3.2', '< 5.2'
 
   spec.add_development_dependency "appraisal", "~> 2.0"
   spec.add_development_dependency "bundler", "~> 1.13"


### PR DESCRIPTION
`appraisal rake` works for Rails 3 through 5.1 now. This gem is currently broken for Rails 5.1 because of https://github.com/rails/rails/commit/83b767cef90abfc4c2ee9f4b451b0215501fae9a